### PR TITLE
Set Content-Length to 0 for DELETE requests.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -97,6 +97,10 @@
           return log.debug("" + req.method + " " + proxyName + req.url);
         });
         req.headers['host'] = proxyName;
+        if (req.method === 'DELETE') {
+          log.info("Method is DELETE");
+          req.headers['Content-Length'] = 0;
+        }
         return proxy.proxyRequest(req, res, {
           host: config.proxyHost,
           port: config.proxyPort


### PR DESCRIPTION
This is a hacky solution for http-node-proxy sending a Transfer Encoding header to the proxy requests in the absence of a body and Content-Length header.

Ideally, one should check whether the body is indeed empty before indiscriminately setting the Content-Length to 0.
