### PR TITLE
Fix bugs in knit-write.

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -1,10 +1,13 @@
+/*globals console*/
 var path = require('path'),
+    colors = require('colors'),
     fs = require('fs'),
     async = require('async'),
     extendStream = require('./extend-stream'),
     utils = require('./utils');
 
 module.exports = function (resourcesOrStructure, config, callback) {
+    "use strict";
     // We do not handle folder resources here, assume resources are
     // all valid files.
 
@@ -16,7 +19,7 @@ module.exports = function (resourcesOrStructure, config, callback) {
     if (typeof config.overwrite !== 'boolean') config.overwrite = false;
     config.buildpath = path.resolve(config.buildpath || './dist'); // Make absolute
 
-    console.log("Writing to", config.buildpath);
+    console.log("Writing to: ", config.buildpath);
 
     function doWrite (task, callback) {
         var pathname = task.pathname,
@@ -41,19 +44,16 @@ module.exports = function (resourcesOrStructure, config, callback) {
         } else {
             callback("ALREADY EXISTS", task);
         }
-    };
+    }
 
     function writeCallback (error, task) {
         i++;
         if (error) {
-            console.error(i.toString(), "FAILED WRITE", task.pathname);
+            console.error((i.toString() + "FAILED WRITE" + task.pathname).red);
             errors.push(error);
         } else {
-            console.error(i.toString(), "WROTE",
-                          task.href.split('?', 1)[0],
-                          task.buffer.length, "bytes");
-        }
-    };
+            console.log((i.toString() + "WROTE" + task.href).green); }
+    }
 
     // write task = { pathname, generator, context }
     writeQueue = async.queue(doWrite, writeConcurrency);
@@ -61,10 +61,14 @@ module.exports = function (resourcesOrStructure, config, callback) {
         callback(errors.length > 0 ? errors : undefined);
     };
 
-    for (href in resources)
-        writeQueue.push({
-            pathname: path.join(config.buildpath, href),
-            generator: resources[href],
-            context: config.context
-        }, writeCallback);
+    for (href in resources) {
+        if (resources.hasOwnProperty(href)) {
+            writeQueue.push({
+                pathname: path.join(config.buildpath, href),
+                generator: resources[href],
+                href: href,
+                context: config.context
+            }, writeCallback);
+        }
+    }
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dependencies": {
         "stream-buffers": "~0.2.3",
         "async": "~0.1.22",
-        "mime": "~1.2.7"
+        "mime": "~1.2.7",
+        "colors": "~0.6.0"
     },
     "devDependencies": {
         "vows": "0.6.x"


### PR DESCRIPTION
`knit.write` assumed that the tasks would have 'href' and 'buffer' property. I have removed that restriction. Also, have added some color to the output.
